### PR TITLE
Use quality 90 for pngquant

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class GL{
                   return callback(null, buffer, { 'Content-Type': 'image/png' });
               });
 
-              png.pack().pipe(new PngQuant(['-quality', 90)).pipe(concatStream);
+              png.pack().pipe(new PngQuant(['-quality', 90])).pipe(concatStream);
           });
       });
   };

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class GL{
                   return callback(null, buffer, { 'Content-Type': 'image/png' });
               });
 
-              png.pack().pipe(new PngQuant()).pipe(concatStream);
+              png.pack().pipe(new PngQuant(['-quality', 90)).pipe(concatStream);
           });
       });
   };


### PR DESCRIPTION
 creates 30% smaller png files with no visual artifacts when using the current map tiles
