### PR TITLE
Add raw output format option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "concat-stream": "^1.5.1",
     "generic-pool": "^2.4.2",
+    "lodash": "^4.16.4",
     "mapbox-gl-native": "^3.1.3",
     "pngjs": "^2.3.1",
     "pngquant": "^1.0.0",


### PR DESCRIPTION
Makes it possible to specify `format: "raw"` in `getStatic` options and get a raw buffer instead of PNG (default).
